### PR TITLE
Added pkg-config to build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: testrunner-lite
 Section: misc
 Priority: optional
 Maintainer: Sampo Saaristo <ext-sampo.2.saaristo@nokia.com>
-Build-Depends: debhelper (>= 5), libtool, autoconf, libxml2-dev, doxygen, check, libcurl3-dev, libtool, libssh2-1-dev, uuid-dev
+Build-Depends: debhelper (>= 5), libtool, autoconf, libxml2-dev, doxygen, check, libcurl3-dev, libtool, libssh2-1-dev, uuid-dev, pkg-config
 Standards-Version: 3.8.0
 
 Package: testrunner-lite


### PR DESCRIPTION
Atleast on debian 8, pkg-config is now installed by default and when checking
for "check" test library, pkg-config seems to be required, thus package build
fails.