### PR TITLE
testrunner-lite: Fix xml2 compilation error.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,7 +27,7 @@ testrunner_lite_SOURCES = main.c \
 testrunner_lite_LDADD = $(XML2_LIBS) -lcurl -ldl -luuid
 
 AM_CPPFLAGS = -DLIBDIR=\"$(libdir)\"
-AM_CFLAGS = $(XML2_CFLAGS)-D_GNU_SOURCE -Wall
+AM_CFLAGS = $(XML2_CFLAGS) -D_GNU_SOURCE -Wall
 
 noinst_HEADERS = testrunnerlite.h \
 	         testdefinitionparser.h \


### PR DESCRIPTION
[testrunner-lite] Fix xml2 compilation error. Fixes JB#47143

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>